### PR TITLE
build wg-userspace, adjust debug set

### DIFF
--- a/distrib/sets/lists/debug/mi
+++ b/distrib/sets/lists/debug/mi
@@ -1332,6 +1332,8 @@
 ./usr/libdata/debug/usr/sbin/vnconfig.debug	comp-sysutil-debug	debug
 ./usr/libdata/debug/usr/sbin/wake.debug		comp-obsolete		obsolete,compatfile
 ./usr/libdata/debug/usr/sbin/wakeonlan.debug	comp-netutil-debug	debug
+./usr/libdata/debug/usr/sbin/wg-keygen.debug	comp-netutil-debug	debug
+./usr/libdata/debug/usr/sbin/wgconfig.debug	comp-netutil-debug	debug
 ./usr/libdata/debug/usr/sbin/wiconfig.debug	comp-sysutil-debug	debug
 ./usr/libdata/debug/usr/sbin/wire-test.debug	comp-netutil-debug	debug
 ./usr/libdata/debug/usr/sbin/wlanctl.debug	comp-sysutil-debug	debug

--- a/usr.sbin/Makefile
+++ b/usr.sbin/Makefile
@@ -30,7 +30,7 @@ SUBDIR=	ac accton acpitools altq apm apmd arp autofs \
 	tadpolectl tcpdchk tcpdmatch tcpdrop timed tpctl tprof traceroute trpt \
 	unlink usbdevs user \
 	videomode vipw veriexecgen vnconfig \
-	wakeonlan wg-keygen wgconfig wiconfig wlanctl wsconscfg wsfontload wsmoused \
+	wakeonlan wg-keygen wg-userspace wgconfig wiconfig wlanctl wsconscfg wsfontload wsmoused \
 	wsmuxctl zdump zic
 
 .if ${MKMAKEMANDB} != "no"


### PR DESCRIPTION
This fixes two small omissions related to the set file lists:
- wg-userspace is in the file lists, but is not built. Add it to the parent Makefile.
- wg-keygen and wgconfig are missing from the debug set list. Add them.