### PR TITLE
set multicast flag on wg interfaces

### DIFF
--- a/sys/net/if_wg.c
+++ b/sys/net/if_wg.c
@@ -3147,7 +3147,7 @@ wg_if_attach(struct wg_softc *wg)
 
 	wg->wg_if.if_addrlen = 0;
 	wg->wg_if.if_mtu = WG_MTU;
-	wg->wg_if.if_flags = IFF_POINTOPOINT;
+	wg->wg_if.if_flags = IFF_POINTOPOINT | IFF_MULTICAST;
 	wg->wg_if.if_extflags = IFEF_NO_LINK_STATE_CHANGE;
 	wg->wg_if.if_extflags |= IFEF_MPSAFE;
 	wg->wg_if.if_ioctl = wg_ioctl;


### PR DESCRIPTION
I run OSPF over my Wireguard links, so I need multicast to work. We generally have the multicast flag set on point-to-point interfaces, so I think it should be this way for Wireguard, as well.